### PR TITLE
adding scheme finalizer

### DIFF
--- a/pkg/generators/builder/builder.go
+++ b/pkg/generators/builder/builder.go
@@ -117,9 +117,9 @@ func (b *BuilderPatternGenerator) Finalize(c *generator.Context, w io.Writer) er
 	}
 
 	snippet := `
-	func AddToScheme(runtime *runtime.Scheme){
+	func AddToSchemeOrPanic(s *runtime.Scheme){
 		$- range .PackageAliases$
-			$.alias$.SchemeBuilder.AddToScheme(runtime)
+			utilruntime.Must($.alias$.SchemeBuilder.AddToScheme(s))
 		$- end$
 	}
 	`
@@ -211,12 +211,19 @@ func (b *BuilderPatternGenerator) Namers(c *generator.Context) namer.NameSystems
 }
 
 func (b *BuilderPatternGenerator) Imports(c *generator.Context) (imports []string) {
+	b.imports.AddType(&types.Type{
+		Name: types.Name{
+			Name:    "Runtime",
+			Package: "k8s.io/apimachinery/pkg/util/runtime",
+		},
+	})
 	importLines := []string{"k8s.io/apimachinery/pkg/runtime"}
 	for _, singleImport := range b.imports.ImportLines() {
 		if b.isNotTargetPackage(singleImport) {
 			importLines = append(importLines, singleImport)
 		}
 	}
+
 	return importLines
 }
 

--- a/pkg/generators/builder/builder_test.go
+++ b/pkg/generators/builder/builder_test.go
@@ -130,3 +130,13 @@ func TestBuilderPattern_GenerateInit(t *testing.T) {
 	assert.NoError(t, g.Init(c, buf))
 	assert.Contains(t, buf.String(), "mergeMapStringString")
 }
+
+func TestBuilderPattern_GenerateFinalize(t *testing.T) {
+	b := &BuilderPatternGeneratorFactory{}
+	pkg, _ := newTestGeneratorType(t, "c", "CDeployment")
+	g := b.NewBuilder(pkg)
+	buf := &bytes.Buffer{}
+	c := newGeneratorContext(g)
+	assert.NoError(t, g.Finalize(c, buf))
+	assert.Contains(t, buf.String(), "// Finalize")
+}

--- a/pkg/generators/builder/builder_test.go
+++ b/pkg/generators/builder/builder_test.go
@@ -130,6 +130,17 @@ func TestBuilderPattern_GenerateInit(t *testing.T) {
 	assert.Contains(t, buf.String(), "mergeMapStringString")
 }
 
+func TestBuilderPattern_GenerateAddToSchemeOrPanic(t *testing.T) {
+	b := &BuilderPatternGeneratorFactory{}
+	pkg, typeToGenerate := newTestGeneratorType(t, "c", "CDeployment")
+	g := b.NewBuilder(pkg)
+	buf := &bytes.Buffer{}
+	c := newGeneratorContext(g)
+	assert.NoError(t, g.GenerateType(c, typeToGenerate, buf))
+	assert.NoError(t, g.Finalize(c, buf))
+	assert.Equal(t, strings.Count(buf.String(), "cd.SchemeBuilder"), 1)
+}
+
 func TestBuilderPattern_GenerateFinalize(t *testing.T) {
 	b := &BuilderPatternGeneratorFactory{}
 	pkg, _ := newTestGeneratorType(t, "c", "CDeployment")

--- a/pkg/generators/builder/builder_test.go
+++ b/pkg/generators/builder/builder_test.go
@@ -115,10 +115,9 @@ func TestBuilderPattern_TypeMetaGeneratesImportLines(t *testing.T) {
 	assert.NoError(t, g.GenerateType(c, typeToGenerate, &bytes.Buffer{}))
 
 	imports := g.Imports(c)
-	assert.Len(t, imports, 2)
 	assert.Contains(t, strings.Join(imports, ""), "cmeta")
 	assert.Contains(t, strings.Join(imports, ""), "cd")
-
+	assert.Contains(t, strings.Join(imports, ""), "utilruntime")
 }
 
 func TestBuilderPattern_GenerateInit(t *testing.T) {

--- a/pkg/generators/snippets/scheme.go
+++ b/pkg/generators/snippets/scheme.go
@@ -1,0 +1,19 @@
+package snippets
+
+import "k8s.io/gengo/generator"
+
+func GenerateAddToScheme(importAliases []string) (string, generator.Args) {
+	snippet := `
+	func AddToSchemeOrPanic(s *runtime.Scheme){
+		$- range .PackageAliases$
+			utilruntime.Must($.$.SchemeBuilder.AddToScheme(s))
+		$- end$
+	}
+	`
+
+	args := generator.Args{
+		"PackageAliases": importAliases,
+	}
+
+	return snippet, args
+}

--- a/pkg/generators/snippets/scheme_test.go
+++ b/pkg/generators/snippets/scheme_test.go
@@ -1,0 +1,44 @@
+package snippets
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/gengo/generator"
+)
+
+func TestGenerateAddToScheme_Snippet(t *testing.T) {
+	ctx, err := newTestGeneratorContext()
+	require.NoError(t, err)
+
+	tests := []struct {
+		description string
+		aliases     []string
+	}{
+		{
+			description: "empty function",
+		},
+		{
+			description: "single alias",
+			aliases:     []string{"a"},
+		},
+		{
+			description: "multiple alias",
+			aliases:     []string{"a", "b"},
+		},
+	}
+
+	for _, test := range tests {
+		var b bytes.Buffer
+		sw := generator.NewSnippetWriter(&b, ctx, "$", "$")
+		sw.Do(GenerateAddToScheme(test.aliases))
+		assert.Equal(t, strings.Count(b.String(), "SchemeBuilder"), len(test.aliases), test.description)
+		for _, a := range test.aliases {
+			assert.Equal(t, strings.Count(b.String(), fmt.Sprintf("%s.SchemeBuilder", a)), 1, test.description)
+		}
+	}
+}


### PR DESCRIPTION
Adds a Finalizer to the builder that will generate the `AddToScheme` snippets.

Each K8s runtime type (including extensions) use the client code [generator](https://github.com/kubernetes/code-generator/blob/master/cmd/client-gen/generators/scheme/generator_for_scheme.go) to assemble the schemes for the defined types.  

This builder is essentially doing the same thing.  It will add a function `AddToSchemeOrPanic` to each package.  The contents of this function will be a unique list of versioned runtime types.  

For example given the types
```
import (
	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
)

type Certificate struct {
	v1.Certificate
}
```

The runtime package `v1` will be added to the function 

```
import (
	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
	"k8s.io/apimachinery/pkg/runtime"
	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
)

func AddToSchemeOrPanic(s *runtime.Scheme) {
	utilruntime.Must(certmanagerv1.SchemeBuilder.AddToScheme(s))
}
```

