### PR TITLE
Add tag handlers for method receiver type

### DIFF
--- a/pkg/generators/builder/builder.go
+++ b/pkg/generators/builder/builder.go
@@ -37,7 +37,7 @@ func (d *BuilderPatternGeneratorFactory) NewBuilder(pkg *types.Package) generato
 }
 
 func isAllTypes(pkg *types.Package) bool {
-	return tags.IsPackageTagged(tags.Extract(pkg.Comments))
+	return tags.IsPackageTagged(pkg.Comments)
 }
 
 func newImportTracker() namer.ImportTracker {

--- a/pkg/generators/generators.go
+++ b/pkg/generators/generators.go
@@ -48,8 +48,7 @@ func (g *Generators) Packages(context *generator.Context, arguments *args.Genera
 	packages := generator.Packages{}
 	for _, v := range context.Inputs {
 		pkg := context.Universe[v]
-		tagValue := tags.Extract(pkg.Comments)
-		if tags.IsPackageTagged(tagValue) || doPackageTypesNeedGeneration(pkg) {
+		if tags.IsPackageTagged(pkg.Comments) || doPackageTypesNeedGeneration(pkg) {
 			log.Infof("Package: %s marked for generation.", pkg.Name)
 			packages = append(packages, &generator.DefaultPackage{
 				PackageName:   pkg.Name,

--- a/pkg/generators/tags/tags.go
+++ b/pkg/generators/tags/tags.go
@@ -7,26 +7,39 @@ import (
 )
 
 const (
-	Name    = "kanopy:builder"
-	Package = "package"
+	Builder         = "kanopy:builder"
+	Builder_Package = "package"
+	Builder_OptIn   = "true"
+	Builder_OptOut  = "false"
+	Receiver        = "kanopy:receiver"
+	Receiver_Ptr    = "ptr"
+	Receiver_Value  = "value"
 )
 
-func IsPackageTagged(tag string) bool {
-	return tag == Package
+func IsPackageTagged(comments []string) bool {
+	return Extract(comments, Builder) == Builder_Package
 }
 
 func IsTypeEnabled(t *types.Type) bool {
-	tag := Extract(combineTypeComments(t))
-	return tag == "true"
+	return Extract(combineTypeComments(t), Builder) == Builder_OptIn
 }
 
 func IsTypeOptedOut(t *types.Type) bool {
-	tag := Extract(combineTypeComments(t))
-	return tag == "false"
+	return Extract(combineTypeComments(t), Builder) == Builder_OptOut
 }
 
-func Extract(comments []string) string {
-	vals := types.ExtractCommentTags("+", comments)[Name]
+func IsPtrReceiver(t *types.Type) bool {
+	val := Extract(combineTypeComments(t), Receiver)
+	// default to Pointer Receiver if unspecified
+	return (val == Receiver_Ptr) || (val == "")
+}
+
+func IsValueReceiver(t *types.Type) bool {
+	return Extract(combineTypeComments(t), Receiver) == Receiver_Value
+}
+
+func Extract(comments []string, tag string) string {
+	vals := types.ExtractCommentTags("+", comments)[tag]
 	if len(vals) == 0 {
 		return ""
 	}

--- a/pkg/generators/tags/tags_test.go
+++ b/pkg/generators/tags/tags_test.go
@@ -14,38 +14,50 @@ func TestExtractCommentTag(t *testing.T) {
 	fmtTag := "+%s=%s"
 	tests := []struct {
 		description string
+		tag         string
 		comments    []string
 		want        string
 	}{
 		{
 			description: "Empty value from no comments",
+			tag:         Builder,
 			comments:    []string{},
 			want:        "",
 		},
 		{
 			description: "Empty value from empty comments",
+			tag:         Builder,
 			comments:    []string{""},
 			want:        "",
 		},
 		{
 			description: "Value from comments",
-			comments:    []string{fmt.Sprintf(fmtTag, Name, "value")},
+			tag:         Builder,
+			comments:    []string{fmt.Sprintf(fmtTag, Builder, "value")},
 			want:        "value",
 		},
 		{
 			description: "Tag with no value",
-			comments:    []string{fmt.Sprintf(fmtTag, Name, "")},
+			tag:         Builder,
+			comments:    []string{fmt.Sprintf(fmtTag, Builder, "")},
 			want:        "",
 		},
 		{
 			description: "Return first value with multiple values",
-			comments:    []string{fmt.Sprintf(fmtTag, Name, "value,value2")},
+			tag:         Builder,
+			comments:    []string{fmt.Sprintf(fmtTag, Builder, "value,value2")},
 			want:        "value",
+		},
+		{
+			description: "Receiver tag",
+			tag:         Receiver,
+			comments:    []string{fmt.Sprintf(fmtTag, Receiver, "ptr")},
+			want:        "ptr",
 		},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.want, Extract(test.comments), test.description)
+		assert.Equal(t, test.want, Extract(test.comments, test.tag), test.description)
 	}
 }
 
@@ -58,7 +70,16 @@ func TestTypeOptOut(t *testing.T) {
 }
 
 func TestAllPackageTypes(t *testing.T) {
-	assert.True(t, IsPackageTagged(Extract(getTestPackage(t).Comments)))
+	assert.True(t, IsPackageTagged(getTestPackage(t).Comments))
+}
+
+func TestPtrReceiver(t *testing.T) {
+	assert.True(t, IsPtrReceiver(getTestPackage(t).Types["UnspecifiedReceiver"]))
+	assert.True(t, IsPtrReceiver(getTestPackage(t).Types["PtrReceiver"]))
+}
+
+func TestValueReceiver(t *testing.T) {
+	assert.True(t, IsValueReceiver(getTestPackage(t).Types["ValueReceiver"]))
 }
 
 func getTestPackage(t *testing.T) *types.Package {

--- a/pkg/generators/tags/testdata/a/receiver.go
+++ b/pkg/generators/tags/testdata/a/receiver.go
@@ -1,0 +1,15 @@
+package a
+
+// +kanopy:builder=true
+type UnspecifiedReceiver struct {
+}
+
+// +kanopy:builder=true
+// +kanopy:receiver=ptr
+type PtrReceiver struct {
+}
+
+// +kanopy:builder=false
+// +kanopy:receiver=value
+type ValueReceiver struct {
+}


### PR DESCRIPTION
Adds detection for the method receiver type to be generated for a struct.
```
// +kanopy:builder=true
// +kanopy:receiver=ptr
type PtrReceiver struct {
}

// +kanopy:builder=false
// +kanopy:receiver=value
type ValueReceiver struct {
}

// +kanopy:builder=true
type UnspecifiedReceiver struct {
    // defaults to pointer receiver if left unspecified.
}
```

The `Extract` function was changed to take in a `tag` argument so that it can be used to extract any tag.
`IsPackageTagged` was changed to take in `comments []string` to flow better with its uses.