### PR TITLE
Detect if member is Read-only

### DIFF
--- a/pkg/generators/tags/tags.go
+++ b/pkg/generators/tags/tags.go
@@ -38,6 +38,15 @@ func IsValueReceiver(t *types.Type) bool {
 	return Extract(combineTypeComments(t), Receiver) == ReceiverValue
 }
 
+func IsMemberReadyOnly(m types.Member) bool {
+	for _, s := range m.CommentLines {
+		if strings.Contains(s, "Read-only") {
+			return true
+		}
+	}
+	return false
+}
+
 func Extract(comments []string, tag string) string {
 	vals := types.ExtractCommentTags("+", comments)[tag]
 	if len(vals) == 0 {

--- a/pkg/generators/tags/tags_test.go
+++ b/pkg/generators/tags/tags_test.go
@@ -84,6 +84,12 @@ func TestValueReceiver(t *testing.T) {
 	assert.False(t, IsValueReceiver(getTestPackage(t).Types["UnspecifiedReceiver"]))
 }
 
+func TestMemberReadyOnly(t *testing.T) {
+	testType := getTestPackage(t).Types["StructWithMemberComments"]
+	assert.False(t, IsMemberReadyOnly(getMemberByName(t, testType, "Name")))
+	assert.True(t, IsMemberReadyOnly(getMemberByName(t, testType, "UID")))
+}
+
 func getTestPackage(t *testing.T) *types.Package {
 	testDir := "./testdata/a"
 	d := args.Default()
@@ -95,4 +101,15 @@ func getTestPackage(t *testing.T) *types.Package {
 	findTypes, err := b.FindTypes()
 	assert.NoError(t, err)
 	return findTypes[testDir]
+}
+
+func getMemberByName(t *testing.T, inputType *types.Type, name string) types.Member {
+	for _, m := range inputType.Members {
+		if m.Name == name {
+			return m
+		}
+	}
+
+	t.Fatalf("failed to find %q in type %q", name, inputType)
+	return types.Member{}
 }

--- a/pkg/generators/tags/tags_test.go
+++ b/pkg/generators/tags/tags_test.go
@@ -85,7 +85,7 @@ func TestValueReceiver(t *testing.T) {
 }
 
 func TestMemberReadyOnly(t *testing.T) {
-	testType := getTestPackage(t).Types["StructWithMemberComments"]
+	testType := getTestPackage(t).Types["MemberComments"]
 	assert.False(t, IsMemberReadyOnly(getMemberByName(t, testType, "Name")))
 	assert.True(t, IsMemberReadyOnly(getMemberByName(t, testType, "UID")))
 }

--- a/pkg/generators/tags/testdata/a/readonly.go
+++ b/pkg/generators/tags/testdata/a/readonly.go
@@ -1,0 +1,17 @@
+package a
+
+type StructWithMemberComments struct {
+	// This member can be set.
+	//
+	// Comments are gibberish...
+	// Name must be unique within a namespace.
+	// Cannot be updated.
+	// +optional
+	Name string
+
+	// This member cannot be set.
+	//
+	// Populated by the system.
+	// Read-only.
+	UID string
+}

--- a/pkg/generators/tags/testdata/a/readonly.go
+++ b/pkg/generators/tags/testdata/a/readonly.go
@@ -1,6 +1,6 @@
 package a
 
-type StructWithMemberComments struct {
+type MemberComments struct {
 	// This member can be set.
 	//
 	// Comments are gibberish...


### PR DESCRIPTION
Add a function under tags package, `IsMemberReadyOnly` to check if the member's comments contains "Read-only".
This will be used later in the Builder to skip generating setters for these members.

```
type StructWithMemberComments struct {
	// This member can be set
	Name string

	// Read-only.
	UID string
}
```