### PR TITLE
Bugfix: use mergeMapStringString for map[string]string

### DIFF
--- a/pkg/generators/builder/builder.go
+++ b/pkg/generators/builder/builder.go
@@ -135,8 +135,10 @@ func (b *BuilderPatternGenerator) generateSettersForType(sw *generator.SnippetWr
 
 		switch {
 		case m.Type.Kind == types.Map:
-			switch parent.Name.Name {
-			case ObjectMeta:
+			keyType := m.Type.Key
+			elemType := m.Type.Elem
+			switch {
+			case keyType == types.String && elemType == types.String:
 				sw.Do(setter.GenerateSetterForMapStringString(m))
 			default:
 				sw.Do(setter.GenerateSetterForMap(m))


### PR DESCRIPTION
Follow up to previous PR https://github.com/kanopy-platform/code-generator/pull/18 where we differentiated between generating a setter for ObjectMeta map versus any other maps.

I don't know why I didn't just check if type is `map[string]string` then use `mergeMapStringString` function. But here is the fix. With this change setters for `map[string]string` outside of ObjectMeta will also utilize `mergeMapStringString`

https://github.com/10gen/kanopy/pull/262 shows the result. Kanopy dry-runs were clean.

For unit test coverage, this [test](https://github.com/kanopy-platform/code-generator/blob/main/pkg/generators/builder/builder_test.go#L142) covers that `map[string]string` setter is generated, and this [test](https://github.com/kanopy-platform/code-generator/blob/main/pkg/generators/builder/builder_test.go#L152) covers that other map types are generated. The actual setter code is left to `setters_test.go`