### PR TITLE
Bugfix: update .drone.yml to align golang 1.17 as in go.mod

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,7 @@ steps:
       - licensed status
 
   - name: snyk
-    image: snyk/snyk:golang-1.16
+    image: snyk/snyk:golang-1.17
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token
@@ -65,7 +65,7 @@ steps:
 
   # tag a new release
   - name: dist
-    image: golang:1.16
+    image: golang:1.17
     commands:
       - make dist
     when:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current version
-const Version = "0.1.0"
+const Version = "0.1.1"


### PR DESCRIPTION
The `dist` step in .drone.yml is [failing](https://drone.corp.mongodb.com/kanopy-platform/code-generator/136/1/5).

I think it's because was using a `golang:1.16` image while the go.mod specifies [go 1.17](https://github.com/kanopy-platform/code-generator/blob/main/go.mod#L3).

Thus the go.sum probably didn't line up. I think this should fix it.
Will cut a new release after to test.