### PR TITLE
Use case insensitive read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ All kubernetes runtime types have the following in common. They embed [ObjectMet
 - Given a type with ObjectMeta
   - generate a Constructor that accepts the name of the resources
   - generate DeepCopy and DeepCopyInto wrappers of the parent type
-  - generate members of ObjectMeta not tagged as `// Read-only`
+  - generate members of ObjectMeta not tagged as `// Read-only` (case insensitive)
 
 - Given a type with Builtin / Primitive members
-  - generate setter functions for each member not tagged as `// Read-only`.
+  - generate setter functions for each member not tagged as `// Read-only` (case insensitive).

--- a/pkg/generators/builder/member_test.go
+++ b/pkg/generators/builder/member_test.go
@@ -24,10 +24,17 @@ func TestIncludeMember(t *testing.T) {
 			want:         true,
 		},
 		{
-			description:  "should not include Read-only member",
+			description:  "should not include member labeled Read-only",
 			dir:          "c/meta",
 			typeSelector: "ObjectMeta",
 			member:       "ReadOnlyMember",
+			want:         false,
+		},
+		{
+			description:  "should not include member labeled read-only (lowercase)",
+			dir:          "c/meta",
+			typeSelector: "ObjectMeta",
+			member:       "ReadOnlyLowerCase",
 			want:         false,
 		},
 	}

--- a/pkg/generators/builder/testdata/c/meta/meta.go
+++ b/pkg/generators/builder/testdata/c/meta/meta.go
@@ -13,6 +13,6 @@ type ObjectMeta struct {
 	IntPtr     *int
 	// Read-only.
 	ReadOnlyMember *string
-	// bla bla read-only
+	// Bla bla read-only
 	ReadOnlyLowerCase int
 }

--- a/pkg/generators/builder/testdata/c/meta/meta.go
+++ b/pkg/generators/builder/testdata/c/meta/meta.go
@@ -13,4 +13,6 @@ type ObjectMeta struct {
 	IntPtr     *int
 	// Read-only.
 	ReadOnlyMember *string
+	// bla bla read-only
+	ReadOnlyLowerCase int
 }

--- a/pkg/generators/tags/tags.go
+++ b/pkg/generators/tags/tags.go
@@ -27,7 +27,7 @@ func IsTypeOptedOut(t *types.Type) bool {
 
 func IsMemberReadyOnly(m types.Member) bool {
 	for _, s := range m.CommentLines {
-		if strings.Contains(s, "Read-only") {
+		if strings.Contains(strings.ToLower(s), "read-only") {
 			return true
 		}
 	}


### PR DESCRIPTION
This change makes `Read-only` fields detection case insensitive.

This is to target k8s ObjectMeta fields:
- SelfLink that is labeled [read-only](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L146)
- Other fields such as UID labeled [Read-only](https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/types.go#L155)

Refer to the Kanopy PR to see generated results.