### PR TITLE
BUGFIX: do not render enum constants if not specified as options

### DIFF
--- a/pkg/generators/snippets/enum.go
+++ b/pkg/generators/snippets/enum.go
@@ -23,8 +23,10 @@ func GenerateEnumSetter(inputType *types.Type, enumOptions []string) (string, ge
 	raw := ""
 
 	for _, val := range enumOptions {
-		raw += fmt.Sprintf(`const $.name$%s $.name$ = "%s"`, toSuffix(val), val)
-		raw += "\n"
+		if val != "" {
+			raw += fmt.Sprintf(`const $.name$%s $.name$ = "%s"`, toSuffix(val), val)
+			raw += "\n"
+		}
 	}
 
 	return raw, args


### PR DESCRIPTION
The introduction of ENUM unintentionally broke primititve type support.

For example if you want to define a type based on a primiitive as follows:

upstream lib
```golang
type MyString string
```

implementor lib
```golang
// +kanopy:builder=true;ref=github.com/project/pkg.MyString
type MyString upstream.MyString
```

The enum was incorrectly attempting to generate constants. This fix causes the snippet ignore constants if the tag arguments are empty.