### PR TITLE
Bugfix Omit Setters for Private Fields

### DIFF
--- a/pkg/generators/builder/member.go
+++ b/pkg/generators/builder/member.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"github.com/kanopy-platform/code-generator/pkg/generators/tags"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 )
 
@@ -14,6 +15,11 @@ func includeMember(parent *types.Type, member types.Member) bool {
 	log.Debugf("includeMember Check %v", member.Name)
 	if tags.IsMemberReadyOnly(member) {
 		log.Debugf("\t member %v is readonly", member.Name)
+		return false
+	}
+
+	if namer.IsPrivateGoName(member.Name) {
+		log.Debugf("\t member %v is private", member.Name)
 		return false
 	}
 

--- a/pkg/generators/builder/member_test.go
+++ b/pkg/generators/builder/member_test.go
@@ -37,6 +37,13 @@ func TestIncludeMember(t *testing.T) {
 			member:       "ReadOnlyLowerCase",
 			want:         false,
 		},
+		{
+			description:  "should not include private member",
+			dir:          "d/e",
+			typeSelector: "MockPolicyRule",
+			member:       "privateField",
+			want:         false,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/generators/builder/testdata/d/e/e.go
+++ b/pkg/generators/builder/testdata/d/e/e.go
@@ -5,7 +5,9 @@ type MockPolicyRule struct {
 	ListOfInts            []int
 	AliasType             *AliasToString
 	ToggleAliasWithoutRef *AnotherAlias
+	privateField          PrivateField
 }
 
+type PrivateField struct{}
 type AliasToString string
 type AnotherAlias string


### PR DESCRIPTION
The builders currently attempt to make builder setters for private fields on struct fields.

This omits any private fields from snippet generation. 

The pkg/builder/member tests have been updated as appropriate. I am also providing a PR in a repo that consumes this tool that will provide instructions for testing there. 